### PR TITLE
Change javacs to thinkdast for buildfile

### DIFF
--- a/code/build.xml
+++ b/code/build.xml
@@ -3,13 +3,13 @@
               Any modifications will be overwritten.
               To include a user specific buildfile here, simply create one in the same
               directory with the processing instruction <?eclipse.ant.import?>
-              as the first entry and export the buildfile again. --><project basedir="." default="build" name="JavaCS">
+              as the first entry and export the buildfile again. --><project basedir="." default="build" name="ThinkDaSt">
     <property environment="env"/>
     <property name="junit.output.dir" value="junit"/>
     <property name="debuglevel" value="source,lines,vars"/>
     <property name="target" value="1.7"/>
     <property name="source" value="1.7"/>
-    <path id="JavaCS.classpath">
+    <path id="ThinkDaSt.classpath">
         <pathelement location="bin"/>
         <pathelement location="lib/jedis-2.8.0.jar"/>
         <pathelement location="lib/jsoup-1.8.3.jar"/>
@@ -41,7 +41,7 @@
         <echo message="${ant.project.name}: ${ant.file}"/>
         <javac debug="true" debuglevel="${debuglevel}" destdir="bin" includeantruntime="false" source="${source}" target="${target}">
             <src path="src"/>
-            <classpath refid="JavaCS.classpath"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </javac>
     </target>
     <target description="Build all projects which reference this project. Useful to propagate changes." name="build-refprojects"/>
@@ -62,304 +62,304 @@
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.WikiSearchTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.WikiSearchTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="WikiPhilosophyTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.WikiPhilosophyTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.WikiPhilosophyTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="Card">
-        <java classname="com.allendowney.javacs.Card" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.Card" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="Crawler">
-        <java classname="com.allendowney.javacs.Crawler" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.Crawler" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="CrawlerTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.CrawlerTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.CrawlerTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="HelloJsoup">
-        <java classname="com.allendowney.javacs.HelloJsoup" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.HelloJsoup" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="Index">
-        <java classname="com.allendowney.javacs.Index" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.Index" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="IndexTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.IndexTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.IndexTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="JedisIndex">
-        <java classname="com.allendowney.javacs.JedisIndex" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.JedisIndex" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="JedisIndexTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.JedisIndexTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.JedisIndexTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="JedisMaker">
-        <java classname="com.allendowney.javacs.JedisMaker" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.JedisMaker" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="JedisTermCounter">
-        <java classname="com.allendowney.javacs.JedisTermCounter" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.JedisTermCounter" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="JedisTermCounterTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.JedisTermCounterTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.JedisTermCounterTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="LinkedListExample">
-        <java classname="com.allendowney.javacs.LinkedListExample" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.LinkedListExample" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="ListClientExample">
-        <java classname="com.allendowney.javacs.ListClientExample" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.ListClientExample" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="ListClientExampleTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.ListClientExampleTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.ListClientExampleTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="ListLinks">
-        <java classname="com.allendowney.javacs.ListLinks" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.ListLinks" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="ListSorter">
-        <java classname="com.allendowney.javacs.ListSorter" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.ListSorter" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="ListSorterTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.ListSorterTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.ListSorterTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="MyArrayList">
-        <java classname="com.allendowney.javacs.MyArrayList" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.MyArrayList" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="MyArrayListSoln">
-        <java classname="com.allendowney.javacs.MyArrayListSoln" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.MyArrayListSoln" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="MyArrayListTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.MyArrayListTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.MyArrayListTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="MyBetterMap">
-        <java classname="com.allendowney.javacs.MyBetterMap" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.MyBetterMap" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="MyBetterMapTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.MyBetterMapTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.MyBetterMapTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="MyFixedHashMap">
-        <java classname="com.allendowney.javacs.MyFixedHashMap" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.MyFixedHashMap" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="MyFixedHashMapTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.MyFixedHashMapTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.MyFixedHashMapTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="MyHashMap">
-        <java classname="com.allendowney.javacs.MyHashMap" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.MyHashMap" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="MyHashMapTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.MyHashMapTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.MyHashMapTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="MyLinearMap">
-        <java classname="com.allendowney.javacs.MyLinearMap" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.MyLinearMap" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="MyLinearMapTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.MyLinearMapTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.MyLinearMapTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="MyLinkedList">
-        <java classname="com.allendowney.javacs.MyLinkedList" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.MyLinkedList" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="MyLinkedListSoln">
-        <java classname="com.allendowney.javacs.MyLinkedListSoln" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.MyLinkedListSoln" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="MyLinkedListTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.MyLinkedListTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.MyLinkedListTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="MyTreeMap">
-        <java classname="com.allendowney.javacs.MyTreeMap" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.MyTreeMap" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="MyTreeMapExample">
-        <java classname="com.allendowney.javacs.MyTreeMapExample" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.MyTreeMapExample" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="MyTreeMapTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.MyTreeMapTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.MyTreeMapTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="ProfileListAdd">
-        <java classname="com.allendowney.javacs.ProfileListAdd" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.ProfileListAdd" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="ProfileMapPut">
-        <java classname="com.allendowney.javacs.ProfileMapPut" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.ProfileMapPut" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="SelectionSort">
-        <java classname="com.allendowney.javacs.SelectionSort" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.SelectionSort" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="SillyArray">
-        <java classname="com.allendowney.javacs.SillyArray" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.SillyArray" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="SillyString">
-        <java classname="com.allendowney.javacs.SillyString" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.SillyString" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="TermCounter">
-        <java classname="com.allendowney.javacs.TermCounter" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.TermCounter" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="TermCounterTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.TermCounterTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.TermCounterTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="WikiCrawler">
-        <java classname="com.allendowney.javacs.WikiCrawler" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.WikiCrawler" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="WikiCrawlerTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.WikiCrawlerTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.WikiCrawlerTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="WikiFetcher">
-        <java classname="com.allendowney.javacs.WikiFetcher" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.WikiFetcher" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="WikiNodeExample">
-        <java classname="com.allendowney.javacs.WikiNodeExample" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.WikiNodeExample" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="WikiParserTest">
         <mkdir dir="${junit.output.dir}"/>
         <junit fork="yes" printsummary="withOutAndErr">
             <formatter type="xml"/>
-            <test name="com.allendowney.javacs.WikiParserTest" todir="${junit.output.dir}"/>
-            <classpath refid="JavaCS.classpath"/>
+            <test name="com.allendowney.thinkdast.WikiParserTest" todir="${junit.output.dir}"/>
+            <classpath refid="ThinkDaSt.classpath"/>
         </junit>
     </target>
     <target name="WikiPhilosophy">
-        <java classname="com.allendowney.javacs.WikiPhilosophy" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.WikiPhilosophy" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="WikiSearch">
-        <java classname="com.allendowney.javacs.WikiSearch" failonerror="true" fork="yes">
-            <classpath refid="JavaCS.classpath"/>
+        <java classname="com.allendowney.thinkdast.WikiSearch" failonerror="true" fork="yes">
+            <classpath refid="ThinkDaSt.classpath"/>
         </java>
     </target>
     <target name="junitreport">


### PR DESCRIPTION
I bought this book to learn/strengthen my DS&A and was trying to do the first exercise but ant wouldn't build. Found out after some time that the build.xml file had incorrect paths, so I changed every instance of "JavaCS" to "ThinkDaSt" on the file, so now the build works perfectly.

Before:
![image](https://user-images.githubusercontent.com/70365928/148729010-393e973e-59c0-429a-a117-c6079b95ed0d.png)

After:
![image](https://user-images.githubusercontent.com/70365928/148728952-358a2446-b9b3-4ee0-b126-bcdf77a59202.png)

So please, author, accept these changes so that future students won't run into this hassle like I did?
